### PR TITLE
Run classification endpoints in FastAPI's threadpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ New endpoint: MITRE ATT&CK technique classification.
   added as a `dev` dependency group.
 - New CI workflow (GitHub Actions) running mypy and the test suite on
   every push to `main` and every pull request.
+- The classification endpoints are now plain (non-async) handlers, so
+  FastAPI runs them in its threadpool and CPU-bound model inference no
+  longer blocks the event loop for concurrent requests.
 - `mypy` and `types-cachetools` are now dev dependencies, so
   `poetry run mypy api/` uses the project virtualenv instead of relying
   on a system-wide mypy that cannot see the dependencies;

--- a/api/routers/classification_router.py
+++ b/api/routers/classification_router.py
@@ -26,8 +26,13 @@ async def root() -> str:
     return "OK"
 
 
+# The classification endpoints are plain ``def``, not ``async def``: FastAPI
+# then runs them in its threadpool, so the synchronous CPU-bound torch
+# inference cannot block the event loop for every other request.
+
+
 @router.post("/classify/severity", response_model=SeverityResponse)
-async def severity_classification_endpoint(
+def severity_classification_endpoint(
     request: SeverityRequest,
 ) -> dict[str, Any]:
     """Classify a vulnerability description's severity.
@@ -43,7 +48,7 @@ async def severity_classification_endpoint(
 
 
 @router.post("/classify/attack-techniques", response_model=AttackTechniquesResponse)
-async def attack_techniques_endpoint(
+def attack_techniques_endpoint(
     request: AttackTechniquesRequest,
 ) -> dict[str, Any]:
     """Rank MITRE ATT&CK techniques for a vulnerability description.


### PR DESCRIPTION
## What

Fixes review item 1 from https://github.com/vulnerability-lookup/ML-Gateway/pull/5#issuecomment-5002458684: both classification endpoints were `async def` but called synchronous CPU-bound torch inference directly, so any prediction-cache miss blocked the event loop — and with it every concurrent request (including the other endpoint and `/`) — for the duration of a forward pass.

## How

The two handlers are now plain `def`: FastAPI automatically executes non-async path operations in its threadpool, keeping the event loop free during inference. No behavioral change to request/response semantics; the prediction caches and their locks were already designed for concurrent access.

Stacked on #5 (base: `attack-technique-classification`) so it lands with the endpoint it fixes; if #5 is merged first, this can be retargeted to `main`.

## Testing

- `poetry run mypy api/ tests/` — clean.
- `poetry run pytest` — 8/8 pass (TestClient exercises threadpool handlers the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)